### PR TITLE
imp route create activity plan on a trip

### DIFF
--- a/controllers/trips.js
+++ b/controllers/trips.js
@@ -55,6 +55,19 @@ const deleteTrip = async (req, res) => {
   }
 }
 
+const createActivityPlan = async (req, res) => {
+  try {
+    req.body.activity = req.params.id
+    const trip = await Trip.findById(req.body.tripId)
+    delete req.body.tripId
+    trip.activityPlans.push(req.body)
+    await trip.save()
+    const newPlan = trip.activityPlans[trip.activityPlans.length - 1]
+    res.status(201).json(newPlan)
+  } catch (err) {
+    res.status(500).json(err)
+  }
+}
 
 export {
   create,
@@ -62,4 +75,5 @@ export {
   show,
   update,
   deleteTrip as delete,
+  createActivityPlan,
 }

--- a/models/trip.js
+++ b/models/trip.js
@@ -3,7 +3,7 @@ import mongoose from 'mongoose'
 const Schema = mongoose.Schema
 
 const activityPlanSchema = new Schema({
-  owner: { type: Schema.Types.ObjectId, ref: 'Profile' },
+  //  owner: { type: Schema.Types.ObjectId, ref: 'Profile' }, //! this to be removed once we are good with testing, I believe it is not needed since the tripOwner is the only one that will create actvity plans.
   activity: {type: Schema.Types.ObjectId, ref: 'Activity'},
   date: {type: String, required: true},
   note: {type: String}

--- a/routes/activities.js
+++ b/routes/activities.js
@@ -1,5 +1,6 @@
 import { Router } from "express";
 import * as activityCtrl from '../controllers/activities.js'
+import * as tripCtrl from '../controllers/trips.js'
 import { decodeUserFromToken, checkAuth } from '../middleware/auth.js'
 
 const router = Router()
@@ -17,6 +18,9 @@ router.get('/:id', checkAuth, activityCtrl.show)
 
 router.post('/',checkAuth, activityCtrl.create) 
 router.post('/:id/reviews', checkAuth, activityCtrl.createReview)
+
+// POST from an activities details, add entry to Trip.activityPlans array
+router.post('/:id/activity-plan', checkAuth, tripCtrl.createActivityPlan)
 
 router.put('/:id', checkAuth, activityCtrl.update)
 


### PR DESCRIPTION
- the intention of the route is to be called from an activity (/activities/:id/activity-plan), but the resource to modify is the trip.  
so the activities router will accept the server request, and then call the trips controller.
- Also changes the trip schema so that the embedded resource for activities plans no longer has a field for it's owner, this is because the trip activity will always be created by the owner of the trip.
- to test this in POSTMAN, you need the id of an activity to put in the route, and the id of a trip to put into the body of the request.
