### PR TITLE
set defaults and enums in  activity schema  for cost and time of day and duration

### DIFF
--- a/models/activity.js
+++ b/models/activity.js
@@ -24,10 +24,15 @@ const activitySchema = new Schema({
   },
   timeOfDay: {
     type:String,
-    enum: ['Daytime', 'Afternoon', 'Evening']
+    enum: ['Morning', 'Afternoon','Daytime','Evening'],
+    default: 'Daytime'
   },
-  duration: Number,
-  cost:String,
+  duration: { type: Number, default: 1},
+  cost: {
+    type: String,
+    enum: ['$','$$','$$$','$$$$'],
+    default: '$'
+  },
   reviews:[reviewSchema]
 },{
   timestamps: true,


### PR DESCRIPTION
- time of day now have Morning as a option in addition to Daytime, Afternoon and Evening, the default is Daytime
- duration has a default of 1 (hour)
- cost has a enums $, $$, $$$, $$$$ default is $

